### PR TITLE
remove map file generation from build in production mode

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -83,7 +83,7 @@ if (process.env.NODE_ENV === "production") {
   config.output.chunkFilename = "[name]-chunk-[chunkhash].min.js";
   config.optimization.chunkIds = "deterministic";
   config.optimization.minimize = true;
-  config.devtool = undefined;
+  config.devtool = false;
 }
 
 export default config;


### PR DESCRIPTION
Currently map files are generated by "yarn build" for production mode as well, which increases the dist directory size and thus the container size.
Since they are not used in production, I suggest to remove the configuration that generates them in production mode.