### PR TITLE
CONSOLE-3303: Move plugin template to the openshift GitHub org - Fix cannot access '/logs/artifacts/integration-tests/screenshots' issue

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -4,12 +4,11 @@ set -exuo pipefail
 
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 SCREENSHOTS_DIR=integration-tests/screenshots
-INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
 
 function copyArtifacts {
   if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then
     echo "Copying artifacts from $(pwd)..."
-    cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/integration-tests/screenshots"
+    cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}"
   fi
 }
 


### PR DESCRIPTION
/assign @jhadvig 

Link to CI failing test: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33499/rehearse-33499-pull-ci-openshift-console-plugin-template-main-e2e-aws-plugin-template/1631109521784967168