### PR TITLE
CONSOLE-3303: Move plugin template to the openshift GitHub org -: Add Dockerfile.ci.test with ENTRYPOINT to failing test in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM docker.io/library/node:16 AS build
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS build
+USER root
+RUN command -v yarn || npm i -g yarn
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app
 RUN yarn install && yarn build
 
-FROM docker.io/library/nginx:stable
+FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
-RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+USER 1001
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Link to CI failing test: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33499/rehearse-33499-pull-ci-openshift-console-plugin-template-main-e2e-aws-plugin-template/1632817170343792640

I will have to update the release repo PR with the Dockerfile.ci.test file if this PR changes look good. 
https://github.com/openshift/release/pull/33499/files#diff-51f0aa858d7d03c2a447beda5b0280f84806b5d830d2d404f564c9005dbdaa81R13
