### PR TITLE
Revert "CONSOLE-3303: Move plugin template to the openshift GitHub org - Change docker images to quay images"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/cajieh0/nodejs:16 AS build
+FROM docker.io/library/node:16 AS build
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app
 RUN yarn install && yarn build
 
-FROM quay.io/cajieh0/nginx:stable
+FROM docker.io/library/nginx:stable
 
 RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html


### PR DESCRIPTION
Reverts openshift/console-plugin-template#16

We shouldn't be referencing personal quay repositories for these images. If we need to use a quay image, we should use one from a Red Hat repository.

/assign @cyril-ui-developer 