### PR TITLE
CONSOLE-3303: Move plugin template to the openshift GitHub org - update-cluster-baseurl

### DIFF
--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -22,6 +22,5 @@ module.exports = defineConfig({
     },
     specPattern: 'tests/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'support/index.ts',
-    baseUrl: 'http://localhost:9000/',
   },
 });

--- a/integration-tests/support/login.ts
+++ b/integration-tests/support/login.ts
@@ -4,11 +4,7 @@ import { masthead } from '../views/masthead';
 declare global {
   namespace Cypress {
     interface Chainable {
-      login(
-        providerName?: string,
-        username?: string,
-        password?: string,
-      ): Chainable<Element>;
+      login(username?: string, password?: string): Chainable<Element>;
       logout(): Chainable<Element>;
     }
   }
@@ -20,28 +16,25 @@ const KUBEADMIN_USERNAME = 'kubeadmin';
 
 // This will add 'cy.login(...)'
 // ex: cy.login('my-idp', 'my-user', 'my-password')
-Cypress.Commands.add(
-  'login',
-  (provider: string, username: string, password: string) => {
-    // Check if auth is disabled (for a local development environment).
-    cy.visit('http://localhost:9000/dashboards'); // visits baseUrl which is set in plugins/index.js
-    cy.window().then((win: any) => {
-      if (win.SERVER_FLAGS?.authDisabled) {
-        return;
-      }
+Cypress.Commands.add('login', (username: string, password: string) => {
+  // Check if auth is disabled (for a local development environment).
+  cy.visit('/'); // visits baseUrl which is set in plugins/index.js
+  cy.window().then((win: any) => {
+    if (win.SERVER_FLAGS?.authDisabled) {
+      return;
+    }
 
-      // Make sure we clear the cookie in case a previous test failed to logout.
-      cy.clearCookie('openshift-session-token');
+    // Make sure we clear the cookie in case a previous test failed to logout.
+    cy.clearCookie('openshift-session-token');
 
-      cy.get('#inputUsername').type(username || KUBEADMIN_USERNAME);
-      cy.get('#inputPassword').type(
-        password || Cypress.env('BRIDGE_KUBEADMIN_PASSWORD'),
-      );
-      cy.get(submitButton).click();
-      masthead.username.shouldBeVisible();
-    });
-  },
-);
+    cy.get('#inputUsername').type(username || KUBEADMIN_USERNAME);
+    cy.get('#inputPassword').type(
+      password || Cypress.env('BRIDGE_KUBEADMIN_PASSWORD'),
+    );
+    cy.get(submitButton).click();
+    masthead.username.shouldBeVisible();
+  });
+});
 
 Cypress.Commands.add('logout', () => {
   // Check if auth is disabled (for a local development environment).

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -4,6 +4,7 @@ set -exuo pipefail
 
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 SCREENSHOTS_DIR=integration-tests/screenshots
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
 
 function copyArtifacts {
   if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then


### PR DESCRIPTION
Adding this fix to address the CI failing tests error in release repo:

`{`cy.visit()` failed trying to load:

http://localhost:9000/dashboards

We attempted to make an http request to this URL but the request failed without a response.

We received this error at the network level:

  > Error: connect ECONNREFUSED 127.0.0.1:9000


`
Prow job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33499/rehearse-33499-pull-ci-openshift-console-plugin-template-main-e2e-aws-plugin-template/1641043117287149568