### PR TITLE
CONSOLE-3303: Move plugin template to the openshift GitHub org - add artifects for screenshots and videos

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -7,9 +7,36 @@ SCREENSHOTS_DIR=integration-tests/screenshots
 INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
 
 function copyArtifacts {
+  oc cluster-info dump > ${ARTIFACT_DIR}/cluster_info.json
+  oc get secrets -A -o wide > ${ARTIFACT_DIR}/secrets.yaml
+  oc get secrets -A -o yaml >> ${ARTIFACT_DIR}/secrets.yaml
+  oc get catalogsource -A -o wide > ${ARTIFACT_DIR}/catalogsource.yaml
+  oc get catalogsource -A -o yaml >> ${ARTIFACT_DIR}/catalogsource.yaml
+  oc get subscriptions -n ${NS} -o wide > ${ARTIFACT_DIR}/subscription_details.yaml
+  oc get subscriptions -n ${NS} -o yaml >> ${ARTIFACT_DIR}/subscription_details.yaml
+  oc get csvs -n ${NS} -o wide > ${ARTIFACT_DIR}/csvs.yaml
+  oc get csvs -n ${NS} -o yaml >> ${ARTIFACT_DIR}/csvs.yaml
+  oc get deployments -n ${NS} -o wide > ${ARTIFACT_DIR}/deployment_details.yaml
+  oc get deployments -n ${NS} -o yaml >> ${ARTIFACT_DIR}/deployment_details.yaml
+  oc get installplan -n ${NS} -o wide > ${ARTIFACT_DIR}/installplan.yaml
+  oc get installplan -n ${NS} -o yaml >> ${ARTIFACT_DIR}/installplan.yaml
+  oc get nodes -o wide > ${ARTIFACT_DIR}/node.yaml
+  oc get nodes -o yaml >> ${ARTIFACT_DIR}/node.yaml
+  for pod in `oc get pods -n ${NS} --no-headers -o custom-columns=":metadata.name"; do
+        echo $pod 
+        oc logs $pod -n ${NS} > ${ARTIFACT_DIR}/${pod}.logs
+  done
+  oc get serviceaccounts -n ${NS} -o wide > ${ARTIFACT_DIR}/serviceaccount.yaml
+  oc get serviceaccounts -n ${NS} -o yaml >> ${ARTIFACT_DIR}/serviceaccount.yaml
+  oc get console.v1.operator.openshift.io cluster -o yaml >> ${ARTIFACT_DIR}/cluster.yaml
+  
   if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then
-    echo "Copying artifacts from $(pwd)..."
-    cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}"
+    if [[ -z "$(ls -A -- "$SCREENSHOTS_DIR")" ]]; then
+      echo "No artifacts were copied."
+    else
+      echo "Copying artifacts from $(pwd)..."
+      cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/screenshots"
+    fi
   fi
 }
 


### PR DESCRIPTION
Adding the artifects for screenshots and videos to help figure out  the [failing tests](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33499/rehearse-33499-pull-ci-openshift-console-plugin-template-main-e2e-aws-plugin-template/1646654396903198720) issue and verify if the `console-plugin-template` installation is successfully in CI env.