### PR TITLE
OCPBUGS-10850: Enable source maps for typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 integration-tests/videos
 integration-tests/screenshots
 integration-tests/.DS_Store
+yarn-error.log
 .DS_Store

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "jsx": "react",
     "allowJs": true,
     "strict": false,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "sourceMap": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Webpack is configured to generate source maps for development builds, but typescript was not. Update tsconfig.json to enable source maps. Also, add yarn-error.log to .gitignore.