### PR TITLE
OCPBUGS-17824: The test that checks if i18n translations are up to date doesn't fail after i18n changes

### DIFF
--- a/test-frontend.sh
+++ b/test-frontend.sh
@@ -7,7 +7,7 @@ OPENSHIFT_CI=${OPENSHIFT_CI:=false}
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 
 yarn i18n
-GIT_STATUS="$(git status --short --untracked-files -- public/locales packages/**/locales)"
+GIT_STATUS="$(git status --short --untracked-files -- locales)"
 if [ -n "$GIT_STATUS" ]; then
   echo "i18n files are not up to date. Run 'yarn i18n' then commit changes."
   git --no-pager diff


### PR DESCRIPTION
Fixed the argument for git status command so it looks into correct locales folder path.