### PR TITLE
Fix issue #57 Hot reload of plugin is broken in 4.14

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -68,6 +68,7 @@ const config: Configuration = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
       'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type, Authorization',
+      'Cache-Control': 'no-store',
     },
     devMiddleware: {
       writeToDisk: true,


### PR DESCRIPTION
Because the dev server has cache enabled thus when the plugin manifest is requested the second time it returns empty content, causing the plugin reload to fail. The fix is to disable the cache on the dev server.