### PR TITLE
OCPBUGS-45901: Remove namespace from ConsolePlugin YAML

### DIFF
--- a/charts/openshift-console-plugin/templates/consoleplugin.yaml
+++ b/charts/openshift-console-plugin/templates/consoleplugin.yaml
@@ -2,7 +2,6 @@ apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: {{ template "openshift-console-plugin.name" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openshift-console-plugin.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
The ConsolePlugin resource is cluster-scoped. It should not have a `metadata.namespace` in its YAML manifest.

Fixes #72 

/assign @jhadvig 