### PR TITLE
CONSOLE-4495: bump deprecated base image 

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: nodejs-16
+  name: nodejs-18
   namespace: openshift
   tag: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS build
+FROM registry.access.redhat.com/ubi9/nodejs-18:latest AS build
 USER root
 RUN command -v yarn || npm i -g yarn
 
@@ -6,7 +6,7 @@ ADD . /usr/src/app
 WORKDIR /usr/src/app
 RUN yarn install && yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi9/nginx-120:latest
 
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
 USER 1001


### PR DESCRIPTION
resolves: #76 

- Update the base image to UBI 9 with Node.js 18
- Update the CI configuration to use Node.js 18