### PR TITLE
OCPBUGS-51342: Fix helm command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additional parameters can be specified if desired. Consult the chart [values](ch
 Install the chart using the name of the plugin as the Helm release name into a new namespace or an existing namespace as specified by the `plugin_console-plugin-template` parameter and providing the location of the image within the `plugin.image` parameter by using the following command:
 
 ```shell
-helm upgrade -i  my-plugin charts/openshift-console-plugin -n plugin__console-plugin-template --create-namespace --set plugin.image=my-plugin-image-location
+helm upgrade -i  my-plugin charts/openshift-console-plugin -n my-namespace --create-namespace --set plugin.image=my-plugin-image-location
 ```
 
 NOTE: When deploying on OpenShift 4.10, it is recommended to add the parameter `--set plugin.securityContext.enabled=false` which will omit configurations related to Pod Security.


### PR DESCRIPTION
The example command used the plugin i18next namespace where it should use the OpenShift namespace on the cluster. The i18next namespace is not a valid OpenShift namespace name, so the command as-written will fail.