### PR TITLE
OCPBUGS-54666: Revert "Detect ipv4/ipv6 socket in pod ip for nginx conf"

### DIFF
--- a/charts/openshift-console-plugin/templates/configmap.yaml
+++ b/charts/openshift-console-plugin/templates/configmap.yaml
@@ -15,7 +15,8 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
+        listen              {{ .Values.plugin.port }} ssl;
+        listen              [::]:{{ .Values.plugin.port }} ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -19,22 +19,6 @@ spec:
       containers:
         - name: {{ template "openshift-console-plugin.name" . }}
           image: {{ required "Plugin image must be specified!" .Values.plugin.image }}
-          command:
-          - /bin/sh
-          - -c
-          - |
-            if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
-              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="{{ .Values.plugin.port }}"
-            else
-              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:{{ .Values.plugin.port }}"
-            fi
-            sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
-            exec nginx -c /tmp/nginx.conf -g 'daemon off;'
-          env:
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           ports:
             - containerPort: {{ .Values.plugin.port }}
               protocol: TCP


### PR DESCRIPTION
Reverts openshift/console-plugin-template#79

Disabling IPv6 is not supported in OpenShift. We should keep the template simple if this isn't needed.