### PR TITLE
NO-JIRA: add imagepullsecret support to chart

### DIFF
--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
             {{- include "openshift-console-plugin.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.plugin.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "openshift-console-plugin.name" . }}
           image: {{ required "Plugin image must be specified!" .Values.plugin.image }}

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -4,6 +4,7 @@ plugin:
   description: ""
   image: ""
   imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   replicas: 2
   port: 9443
   securityContext:


### PR DESCRIPTION
this PR adds:
- a new imagePullSecrets array field to the plugin section in values.yaml (defaulting to empty array)
- a conditional section in the `deployment.yaml` template that includes the pull secrets configuration when provided

closes #86 