### PR TITLE
Add generic operator prompt and shared ResourceTable, ResourceInspect components

### DIFF
--- a/docs/operator-onboarding.md
+++ b/docs/operator-onboarding.md
@@ -1,0 +1,251 @@
+
+# Add a New Operator to the OpenShift Console Plugin
+
+Copy the template, fill in operator details, run it. Works on a clean repo (after `git stash`) or with existing operators already added.
+
+---
+
+## End Goal
+
+- **Operator dashboard** at `/<operator-short-name>`: page title plus one **Card + table per resource kind**. Tables use the shared **ResourceTable** component (see [Existing shared components](#existing-shared-components)).
+- **Sidebar:** The dashboard link appears under **Plugins** in the admin perspective. If the Plugins section does not exist, create it first; then add the operator link. Do not duplicate the section or the link if they already exist.
+- **Per-row actions:** Each custom resource row has an **Inspect** button (navigates to the resource detail page) and a **Delete** button (opens confirmation modal). Both must be **buttons** (not link-styled only): Inspect with a sky-blue background, Delete with a red background.
+- **Resource detail dashboard (inspect page):** Clicking Inspect opens `/<operator-short-name>/inspect/<plural>/[namespace/]<name>`. The **ResourceInspect** component (see [Existing shared components](#existing-shared-components)) shows Metadata, Labels, Annotations, Specification, Status, and Events in a **Card + Grid** layout with a back button—no tabs. When adding a new operator, **extend** ResourceInspect’s maps and models; do not replace its layout or structure.
+- **Optional:** Overview dashboard (summary count cards above tables) per Step 7b. Not required.
+
+---
+
+## Existing Shared Components
+
+The project already includes:
+
+- **`src/components/ResourceTable.tsx`** — Shared table: accepts `columns` (title, optional width), `rows` (cells as React nodes), `loading`, `error`, `emptyStateTitle`, `emptyStateBody`, `selectedProject`, `data-test`. Renders a plain `<table>` with thead/tbody, loading (three-dot loader), error Alert, empty EmptyState, or data rows. Use this for **all** operator resource tables; do not use VirtualizedTable for the dashboard tables.
+- **`ResourceTableRowActions`** (exported from the same file) — Renders Inspect + Delete **buttons** for one row. Accepts `resource: K8sResourceCommon` and `inspectHref: string`. Use it in the Actions cell of each row so `useDeleteModal` is called per row (hooks cannot be called inside `.map()`).
+- **`src/ResourceInspect.tsx`** — Shared resource detail page: Card + Grid layout, back button, Metadata/Labels/Annotations/Spec/Status/Events cards, optional “Show/Hide sensitive data” for spec/status. When adding a new operator, **add** entries to `DISPLAY_NAMES`, `getResourceModel(resourceType)`, and `getPagePath(resourceType)`; do not rewrite the component or change its layout/styling pattern.
+
+---
+
+## Prompt Template (copy, fill, run)
+
+```text
+Add a new operator to this OpenShift console plugin: [OPERATOR_NAME].
+
+Input:
+1) Detect operator using model (pick ONE primary resource for detection):
+   - group: [e.g. myoperator.io]
+   - version: [e.g. v1]
+   - kind: [e.g. MyResource]
+2) Resource kinds to expose (repeat block for each):
+   - group: [e.g. myoperator.io]
+   - version: [e.g. v1]
+   - kind: [e.g. MyResource]
+   - plural: [e.g. myresources]
+   - namespaced: [true/false]
+   - displayName: [e.g. My Resources]
+3) Optional fixed namespace: [NAMESPACE or (none)]
+4) Optional column overrides: [none] or per-resource list of columns (title, id, jsonPath, type?) to use instead of the operator-agnostic algorithm.
+
+Follow the implementation specification in this document exactly.
+Start implementation immediately. Do not ask for confirmation.
+If any input is missing, infer from upstream CRD docs and record inferences in the final summary.
+```
+
+---
+
+## What NOT to Do
+
+- **Do NOT use `consoleFetchJSON`** for operator/CRD detection; use `useK8sModel` only.
+- **Do NOT use VirtualizedTable** for the operator dashboard resource tables; use **ResourceTable** with `columns` and `rows`.
+- **Do NOT call `useDeleteModal` inside a `.map()` callback.** Use a per-row component (e.g. `ResourceTableRowActions`) that receives the resource and calls `useDeleteModal(resource)`.
+- **Do NOT use link-styled-only actions:** Inspect and Delete must be real **buttons** (Inspect = sky blue background, Delete = red). Style them with PatternFly CSS variables in the shared CSS (e.g. `--pf-v6-global--palette--blue-400`, `--pf-v6-global--palette--red-500`).
+- **Do NOT use hex colors** (e.g. `#1e1e1e`, `#374151`) in CSS or inline styles. Use **PatternFly CSS variables only** (e.g. `var(--pf-v6-global--BackgroundColor--200)`, `var(--pf-v6-global--BorderColor--100)`).
+- **Do NOT use `.pf-` or `.co-` prefixed class names** for your own structure (e.g. `co-m-loader`, `co-m-pane__body`). Use **`console-plugin-template__`** prefix for all custom classes.
+- **Do NOT use PatternFly 6 `EmptyStateHeader` or `EmptyStateIcon`**; they do not exist. Use props on `<EmptyState>`: `titleText`, `icon={SearchIcon}`, `headingLevel`.
+- **Do NOT use `Label`’s `variant` prop for status colors.** Use the **`status`** prop: `status="success"` (green), `status="danger"` (red), `status="warning"` (orange). (`variant` is for outline/filled/overflow/add.)
+- **Do NOT use `PageSection variant="light"`**; use `"default"` or `"secondary"`.
+- **Do NOT assume `useActiveNamespace()` returns `'all'`** when all namespaces are selected; it returns **`#ALL_NS#`**.
+- **Do NOT create two separate routes for inspect** (e.g. one for namespaced and one for cluster-scoped). Use **one** route with `path: ["/<operator-short-name>/inspect"]` and `exact: false`; the component parses the rest of the path.
+- **Do NOT put the operator dashboard link under `section: "home"`.** It must be **`section: "plugins"`** so it appears under Plugins.
+- **Do NOT rely on margin alone for spacing between table cards** if it collapses. Use a **wrapper div** with `display: flex`, `flex-direction: column`, and **`gap`** (e.g. `console-plugin-template__dashboard-cards`).
+- **Do NOT add `titleFormat` to table column config** when using the SDK’s `TableColumn` type elsewhere; it is not part of that type. For ResourceTable, columns only have `title` and optional `width`.
+- **Do NOT rewrite `ResourceInspect.tsx`** when adding an operator. Extend its `DISPLAY_NAMES`, `getResourceModel`, and `getPagePath`; keep the existing Card + Grid layout and back button.
+- **Do NOT use `$codeRef` with only the module name** (e.g. `"$codeRef": "CertManagerPage"`) for route components in `console-extensions.json`. The Console ExtensionValidator treats that as the **default** export; if the module uses a **named** export (e.g. `export const CertManagerPage`), the build fails with **"Invalid module export 'default' in extension [N] property 'component'"**. Always use the **`moduleName.exportName`** form (e.g. `"$codeRef": "CertManagerPage.CertManagerPage"`, `"$codeRef": "ResourceInspect.ResourceInspect"`).
+
+---
+
+## Critical Rules (read before coding)
+
+1. **Operator detection:** Use **`useK8sModel`** only. `consoleFetchJSON` to CRD/API-group endpoints fails silently due to RBAC in the console proxy.
+2. **EmptyState (PatternFly 6):** Use `<EmptyState titleText="..." icon={SearchIcon} headingLevel="h2"><EmptyStateBody>...</EmptyStateBody></EmptyState>`.
+3. **`useActiveNamespace`** returns **`#ALL_NS#`** when all namespaces are selected (not `'all'`).
+4. **Inspect route:** Single route with `path: ["/<operator-short-name>/inspect"]`, `exact: false`. Component parses path segments internally.
+5. **Navigation:** Operator link under **Plugins** (`section: "plugins"`). Create Plugins section first if missing; do not duplicate section or link.
+6. **`useK8sWatchResource`:** Use the **`groupVersionKind`** object (`{ group, version, kind }`), not the deprecated `kind` string.
+7. **CSS:** Only PatternFly CSS variables; no hex. Prefix all custom classes with **`console-plugin-template__`**. No naked element selectors that could affect console globally; scope under your classes. **Keyframes names** must be kebab-case (e.g. `console-plugin-template-loader-bounce`).
+8. **i18n namespace:** **`plugin__console-plugin-template`**.
+9. **Cluster-scoped resources:** No Namespace column, no `selectedProject` on the table, inspect URL has 2 segments (`/<plural>/<name>`), no `/namespaces/<ns>/` in delete path.
+10. **`console-extensions.json` component references:** Every route `component` must use **`$codeRef`** in the form **`moduleName.exportName`** (e.g. `CertManagerPage.CertManagerPage`, `ResourceInspect.ResourceInspect`). The plugin SDK resolves a bare module name (e.g. `CertManagerPage`) as the **default** export; our page and inspect components use **named** exports. Using only the module name causes the build to fail with "Invalid module export 'default' in extension [N] property 'component'". Page and ResourceInspect modules must **export const** the component (named export); then reference it as `"<ModuleName>.<ExportName>"` in `console-extensions.json`.
+
+---
+
+## Read-First Files
+
+| File | Purpose |
+|------|--------|
+| `src/components/ResourceTable.tsx` | Shared table API (columns, rows, loading, error, empty); `ResourceTableRowActions` for Inspect/Delete |
+| `src/ResourceInspect.tsx` | Shared inspect page (Card + Grid, back button); extend DISPLAY_NAMES, getResourceModel, getPagePath |
+| `src/hooks/useOperatorDetection.ts` | Operator CRD detection hook |
+| `src/components/crds/index.ts` | K8sModel and TS interfaces per kind |
+| `src/components/crds/Events.ts` | plural → Kind for events |
+| `src/components/OperatorNotInstalled.tsx` | Generic “not installed” empty state |
+| `src/components/<operator-short-name>.css` | Shared operator CSS (cards, tables, buttons, inspect) |
+| `console-extensions.json` | Routes and nav |
+| `package.json` | `consolePlugin.exposedModules` |
+| `locales/en/plugin__console-plugin-template.json` | English strings |
+| `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml` | RBAC for new API groups |
+
+Create any of the above if missing; when they exist, **extend** them (do not replace shared structure).
+
+---
+
+## Naming Conventions
+
+- **OPERATOR_SHORT_NAME:** recognizable short name, lowercase kebab-case (e.g. "cert-manager Operator for Red Hat OpenShift" → `cert-manager`).
+
+| Concept | Pattern | Example |
+|---------|---------|---------|
+| Page path | `/<operator-short-name>` | `/cert-manager` |
+| Page component | `src/<OperatorShortName>Page.tsx` | `src/CertManagerPage.tsx` |
+| Table components | `src/components/<KindPlural>Table.tsx` | `src/components/CertificatesTable.tsx` |
+| CSS | `src/components/<operator-short-name>.css` | `src/components/cert-manager.css` |
+| Inspect (namespaced) | `/<page>/inspect/<plural>/<namespace>/<name>` | `/cert-manager/inspect/certificates/default/my-cert` |
+| Inspect (cluster-scoped) | `/<page>/inspect/<plural>/<name>` | `/cert-manager/inspect/clusterissuers/my-issuer` |
+
+---
+
+## Operator Dashboard Column Selection
+
+Tables MUST follow this column logic (implement when building rows for ResourceTable):
+
+1. **Always:** Name (link to inspect), Namespace (if namespaced).
+2. **Optional:** Columns from CRD `additionalPrinterColumns` (priority 0; priority 1 only if total ≤ 8). Use each column’s `jsonPath`; `type: date` → `<Timestamp>`; status/conditions → Label with **`status`** prop (success/danger/warning).
+3. **Fallback** if no additionalPrinterColumns: Name, Namespace (if namespaced), Status (from `status.conditions[type=Ready]`), Age (`metadata.creationTimestamp`), Actions.
+4. **Always last:** Actions column with **Inspect** button (sky blue) and **Delete** button (red), using **ResourceTableRowActions** so `useDeleteModal` is called per row.
+5. User-provided column overrides (if any) override the above; document them in the summary.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Directories
+
+```bash
+mkdir -p src/hooks src/components/crds
+```
+
+### Step 2 — `src/hooks/useOperatorDetection.ts`
+
+Use `useK8sModel` with `{ group, version, kind }` for the primary resource. Export `OperatorStatus`, `OperatorInfo`, `<OPERATOR>_OPERATOR_INFO`, and `useOperatorDetection()`. If the file exists, add the new operator’s info and extend the hook.
+
+### Step 3 — `src/components/crds/index.ts`
+
+For each resource kind, export a **K8sModel** and a TypeScript interface extending `K8sResourceCommon` with optional `spec`/`status`. Append if the file exists.
+
+### Step 4 — `src/components/crds/Events.ts`
+
+Add `plural: 'Kind'` to **RESOURCE_TYPE_TO_KIND** for each new resource.
+
+### Step 5 — `src/components/OperatorNotInstalled.tsx`
+
+Create only if missing. Generic empty state with `EmptyState` (titleText, icon={SearchIcon}, headingLevel), `EmptyStateBody`, and operator display name message.
+
+### Step 6 — Table components (`src/components/<KindPlural>Table.tsx`)
+
+**Use ResourceTable.** One file per resource kind.
+
+- Build **columns**: array of `{ title, width? }` (Name, Namespace if namespaced, then algorithm columns, then Actions).
+- Build **rows**: from `useK8sWatchResource` list; each row’s **cells** array includes Name (Link to inspect), Namespace if namespaced, Status (Label with **status** prop), Created (Timestamp), and **`<ResourceTableRowActions resource={obj} inspectHref={inspectHref} />`** for the Actions cell.
+- Pass **loading** (`!loaded && !loadError`), **error** (`loadError?.message`), **emptyStateTitle**, **emptyStateBody**, **selectedProject** (namespaced only), **data-test**.
+- **Namespaced:** `selectedProject`, inspect href `/<page>/inspect/<plural>/${namespace}/${name}`.
+- **Cluster-scoped:** no `selectedProject`, inspect href `/<page>/inspect/<plural>/${name}`.
+
+Do **not** use VirtualizedTable or call `useDeleteModal` inside `.map()`.
+
+### Step 7 — CSS (`src/components/<operator-short-name>.css`)
+
+Add only missing classes. Use **PatternFly variables only** (no hex). Include:
+
+- `.console-plugin-template__resource-card` (margin or used in dashboard wrapper).
+- Dashboard cards wrapper: `.console-plugin-template__dashboard-cards` with `display: flex`, `flex-direction: column`, **`gap: var(--pf-v6-global--spacer--xl)`** so tables are not stuck together. Cards inside can have `margin-bottom: 0`.
+- Table styles for ResourceTable (header/data row background, borders, **text-align: left** for table data).
+- Loader (e.g. `.console-plugin-template__loader`, `.console-plugin-template__loader-dot`). **Keyframes** names must be **kebab-case** (e.g. `console-plugin-template-loader-bounce`).
+- Action buttons: `.console-plugin-template__action-inspect` (sky blue background/border), `.console-plugin-template__action-delete` (red), using `var(--pf-v6-global--palette--blue-400)`, `var(--pf-v6-global--palette--red-500)` (and hover variants).
+
+### Step 7b — Optional: Overview dashboard
+
+Optional summary count cards above tables. Component that uses `useK8sWatchResource` per kind and shows counts; Grid + Card; PF variables and `console-plugin-template__` prefix.
+
+### Step 8 — Operator page (`src/<OperatorShortName>Page.tsx`)
+
+- Use **`#ALL_NS#`** (not `'all'`) to derive `selectedProject`.
+- Loading: Spinner or shared loader.
+- Not installed: Helmet, title, OperatorNotInstalled.
+- Main view: Helmet, title, then a **wrapper div** with class `console-plugin-template__dashboard-cards` (flex, column, gap), containing one **Card** per resource kind; each Card has CardTitle and CardBody with the corresponding **Table** component. Pass **selectedProject** only to namespaced tables.
+
+### Step 9 — `src/ResourceInspect.tsx` (extend only)
+
+**Do not rewrite.** The file already implements the resource detail dashboard (Card + Grid, back button, Metadata/Labels/Annotations/Spec/Status/Events, optional sensitive-data toggle). When adding a new operator:
+
+1. **DISPLAY_NAMES:** add `plural: 'Display Name'` for each new resource.
+2. **getResourceModel(resourceType):** add cases returning the new kind’s K8sModel.
+3. **getPagePath(resourceType):** add case returning the operator page path (e.g. `'/cert-manager'`) or extend if multi-operator.
+
+Cluster-scoped: component already handles 2-segment path (plural/name). Keep URL parsing and layout as-is.
+
+### Step 10 — `console-extensions.json`
+
+- **Routes:** Append page route (`exact: true`, path `/<operator-short-name>`, component **`$codeRef` in `moduleName.exportName` form**) and inspect route (`exact: false`, path `["/<operator-short-name>/inspect"]`, component same form).
+- **Component `$codeRef` format (required):** Use **named-export** form so the build does not fail with "Invalid module export 'default'". For the operator page use `"component": { "$codeRef": "<OperatorShortName>Page.<OperatorShortName>Page" }` (e.g. `"CertManagerPage.CertManagerPage"`). For the inspect route use `"component": { "$codeRef": "ResourceInspect.ResourceInspect" }`. Never use only the module name (e.g. `"CertManagerPage"`), as that is resolved as the default export and triggers the ExtensionValidator error.
+- **Plugins section:** If missing, add `console.navigation/section` with `id: "plugins"`, `insertAfter: "observe"`. Add nav link only if not present: `console.navigation/href` with `id: "<operator-short-name>"`, `href: "/<operator-short-name>"`, **`section: "plugins"`**.
+
+### Step 11 — `package.json`
+
+Add to `consolePlugin.exposedModules`: `"<OperatorShortName>Page": "./<OperatorShortName>Page"`. Add `"ResourceInspect": "./ResourceInspect"` only if not already present.
+
+### Step 12 — Locales
+
+Add all new strings to `locales/en/plugin__console-plugin-template.json` (page title, resource display names, empty states, Actions, Inspect, Delete, error messages, etc.). Do not remove existing keys. Include "Plugins" if you added the section.
+
+### Step 13 — RBAC
+
+In `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`, add or append ClusterRoles (and bindings): Reader (get, list, watch) and Admin (get, list, watch, delete) for the new API groups/resources. Use template name `{{ template "openshift-console-plugin.name" . }}-<operator-short-name>-reader` and `-admin`.
+
+---
+
+## Validation
+
+- Run **`yarn build-dev`**. It must succeed (ignore pre-existing `node_modules` errors). If you see **"Invalid module export 'default' in extension [N] property 'component'"**, fix `console-extensions.json`: change each route `component` `$codeRef` from `"ModuleName"` to `"ModuleName.ExportName"` (e.g. `CertManagerPage.CertManagerPage`).
+- Run **`yarn lint`** (eslint + stylelint). Fix any issues in `src/` or CSS.
+
+---
+
+## Definition of Done
+
+- [ ] Operator detected via **useK8sModel** (not consoleFetchJSON).
+- [ ] Plugins section exists; operator link under **Plugins** with **section: "plugins"**.
+- [ ] Dashboard at `/<operator-short-name>` with **ResourceTable** in Cards, wrapped in **dashboard-cards** (gap), **left-aligned** table data.
+- [ ] Inspect and Delete are **buttons** (sky blue and red); **ResourceTableRowActions** used so delete modal works per row.
+- [ ] Inspect opens ResourceInspect at `/<operator-short-name>/inspect/...` with Metadata, Labels, Annotations, Spec, Status, Events (Card + Grid, back button).
+- [ ] ResourceInspect extended with new DISPLAY_NAMES, getResourceModel, getPagePath (no layout rewrite).
+- [ ] No hex colors; no `.pf-`/`.co-` custom structure; keyframes kebab-case.
+- [ ] **Route components in `console-extensions.json`** use `$codeRef` as **`moduleName.exportName`** (e.g. `CertManagerPage.CertManagerPage`, `ResourceInspect.ResourceInspect`); no "Invalid module export 'default'" on build.
+- [ ] Locales and RBAC updated; `yarn build-dev` and `yarn lint` pass.
+
+---
+
+## Final Response Format
+
+1. **Files changed** (created/updated).
+2. **CRDs/resources** used (and any inferred values).
+3. **Validation** (build + lint).
+4. **Assumptions / risks.**

--- a/docs/promts.md
+++ b/docs/promts.md
@@ -1,0 +1,247 @@
+
+# Add a New Operator to the OpenShift Console Plugin
+
+Copy the template, fill in operator details, run it. Works on a clean repo (after `git stash`) or with existing operators already added.
+
+---
+
+## End Goal
+
+- **Operator dashboard** at `/<operator-short-name>`: page title plus one **Card + table per resource kind**. Tables use the shared **ResourceTable** component (see [Existing shared components](#existing-shared-components)).
+- **Sidebar:** The dashboard link appears under **Plugins** in the admin perspective. If the Plugins section does not exist, create it first; then add the operator link. Do not duplicate the section or the link if they already exist.
+- **Per-row actions:** Each custom resource row has an **Inspect** button (navigates to the resource detail page) and a **Delete** button (opens confirmation modal). Both must be **buttons** (not link-styled only): Inspect with a sky-blue background, Delete with a red background.
+- **Resource detail dashboard (inspect page):** Clicking Inspect opens `/<operator-short-name>/inspect/<plural>/[namespace/]<name>`. The **ResourceInspect** component (see [Existing shared components](#existing-shared-components)) shows Metadata, Labels, Annotations, Specification, Status, and Events in a **Card + Grid** layout with a back button—no tabs. When adding a new operator, **extend** ResourceInspect’s maps and models; do not replace its layout or structure.
+- **Optional:** Overview dashboard (summary count cards above tables) per Step 7b. Not required.
+
+---
+
+## Existing Shared Components
+
+The project already includes:
+
+- **`src/components/ResourceTable.tsx`** — Shared table: accepts `columns` (title, optional width), `rows` (cells as React nodes), `loading`, `error`, `emptyStateTitle`, `emptyStateBody`, `selectedProject`, `data-test`. Renders a plain `<table>` with thead/tbody, loading (three-dot loader), error Alert, empty EmptyState, or data rows. Use this for **all** operator resource tables; do not use VirtualizedTable for the dashboard tables.
+- **`ResourceTableRowActions`** (exported from the same file) — Renders Inspect + Delete **buttons** for one row. Accepts `resource: K8sResourceCommon` and `inspectHref: string`. Use it in the Actions cell of each row so `useDeleteModal` is called per row (hooks cannot be called inside `.map()`).
+- **`src/ResourceInspect.tsx`** — Shared resource detail page: Card + Grid layout, back button, Metadata/Labels/Annotations/Spec/Status/Events cards, optional “Show/Hide sensitive data” for spec/status. When adding a new operator, **add** entries to `DISPLAY_NAMES`, `getResourceModel(resourceType)`, and `getPagePath(resourceType)`; do not rewrite the component or change its layout/styling pattern.
+
+---
+
+## Prompt Template (copy, fill, run)
+
+```text
+Add a new operator to this OpenShift console plugin: [OPERATOR_NAME].
+
+Input:
+1) Detect operator using model (pick ONE primary resource for detection):
+   - group: [e.g. myoperator.io]
+   - version: [e.g. v1]
+   - kind: [e.g. MyResource]
+2) Resource kinds to expose (repeat block for each):
+   - group: [e.g. myoperator.io]
+   - version: [e.g. v1]
+   - kind: [e.g. MyResource]
+   - plural: [e.g. myresources]
+   - namespaced: [true/false]
+   - displayName: [e.g. My Resources]
+3) Optional fixed namespace: [NAMESPACE or (none)]
+4) Optional column overrides: [none] or per-resource list of columns (title, id, jsonPath, type?) to use instead of the operator-agnostic algorithm.
+
+Follow the implementation specification in this document exactly.
+Start implementation immediately. Do not ask for confirmation.
+If any input is missing, infer from upstream CRD docs and record inferences in the final summary.
+```
+
+---
+
+## What NOT to Do
+
+- **Do NOT use `consoleFetchJSON`** for operator/CRD detection; use `useK8sModel` only.
+- **Do NOT use VirtualizedTable** for the operator dashboard resource tables; use **ResourceTable** with `columns` and `rows`.
+- **Do NOT call `useDeleteModal` inside a `.map()` callback.** Use a per-row component (e.g. `ResourceTableRowActions`) that receives the resource and calls `useDeleteModal(resource)`.
+- **Do NOT use link-styled-only actions:** Inspect and Delete must be real **buttons** (Inspect = sky blue background, Delete = red). Style them with PatternFly CSS variables in the shared CSS (e.g. `--pf-v6-global--palette--blue-400`, `--pf-v6-global--palette--red-500`).
+- **Do NOT use hex colors** (e.g. `#1e1e1e`, `#374151`) in CSS or inline styles. Use **PatternFly CSS variables only** (e.g. `var(--pf-v6-global--BackgroundColor--200)`, `var(--pf-v6-global--BorderColor--100)`).
+- **Do NOT use `.pf-` or `.co-` prefixed class names** for your own structure (e.g. `co-m-loader`, `co-m-pane__body`). Use **`console-plugin-template__`** prefix for all custom classes.
+- **Do NOT use PatternFly 6 `EmptyStateHeader` or `EmptyStateIcon`**; they do not exist. Use props on `<EmptyState>`: `titleText`, `icon={SearchIcon}`, `headingLevel`.
+- **Do NOT use `Label`’s `variant` prop for status colors.** Use the **`status`** prop: `status="success"` (green), `status="danger"` (red), `status="warning"` (orange). (`variant` is for outline/filled/overflow/add.)
+- **Do NOT use `PageSection variant="light"`**; use `"default"` or `"secondary"`.
+- **Do NOT assume `useActiveNamespace()` returns `'all'`** when all namespaces are selected; it returns **`#ALL_NS#`**.
+- **Do NOT create two separate routes for inspect** (e.g. one for namespaced and one for cluster-scoped). Use **one** route with `path: ["/<operator-short-name>/inspect"]` and `exact: false`; the component parses the rest of the path.
+- **Do NOT put the operator dashboard link under `section: "home"`.** It must be **`section: "plugins"`** so it appears under Plugins.
+- **Do NOT rely on margin alone for spacing between table cards** if it collapses. Use a **wrapper div** with `display: flex`, `flex-direction: column`, and **`gap`** (e.g. `console-plugin-template__dashboard-cards`).
+- **Do NOT add `titleFormat` to table column config** when using the SDK’s `TableColumn` type elsewhere; it is not part of that type. For ResourceTable, columns only have `title` and optional `width`.
+- **Do NOT rewrite `ResourceInspect.tsx`** when adding an operator. Extend its `DISPLAY_NAMES`, `getResourceModel`, and `getPagePath`; keep the existing Card + Grid layout and back button.
+
+---
+
+## Critical Rules (read before coding)
+
+1. **Operator detection:** Use **`useK8sModel`** only. `consoleFetchJSON` to CRD/API-group endpoints fails silently due to RBAC in the console proxy.
+2. **EmptyState (PatternFly 6):** Use `<EmptyState titleText="..." icon={SearchIcon} headingLevel="h2"><EmptyStateBody>...</EmptyStateBody></EmptyState>`.
+3. **`useActiveNamespace`** returns **`#ALL_NS#`** when all namespaces are selected (not `'all'`).
+4. **Inspect route:** Single route with `path: ["/<operator-short-name>/inspect"]`, `exact: false`. Component parses path segments internally.
+5. **Navigation:** Operator link under **Plugins** (`section: "plugins"`). Create Plugins section first if missing; do not duplicate section or link.
+6. **`useK8sWatchResource`:** Use the **`groupVersionKind`** object (`{ group, version, kind }`), not the deprecated `kind` string.
+7. **CSS:** Only PatternFly CSS variables; no hex. Prefix all custom classes with **`console-plugin-template__`**. No naked element selectors that could affect console globally; scope under your classes. **Keyframes names** must be kebab-case (e.g. `console-plugin-template-loader-bounce`).
+8. **i18n namespace:** **`plugin__console-plugin-template`**.
+9. **Cluster-scoped resources:** No Namespace column, no `selectedProject` on the table, inspect URL has 2 segments (`/<plural>/<name>`), no `/namespaces/<ns>/` in delete path.
+
+---
+
+## Read-First Files
+
+| File | Purpose |
+|------|--------|
+| `src/components/ResourceTable.tsx` | Shared table API (columns, rows, loading, error, empty); `ResourceTableRowActions` for Inspect/Delete |
+| `src/ResourceInspect.tsx` | Shared inspect page (Card + Grid, back button); extend DISPLAY_NAMES, getResourceModel, getPagePath |
+| `src/hooks/useOperatorDetection.ts` | Operator CRD detection hook |
+| `src/components/crds/index.ts` | K8sModel and TS interfaces per kind |
+| `src/components/crds/Events.ts` | plural → Kind for events |
+| `src/components/OperatorNotInstalled.tsx` | Generic “not installed” empty state |
+| `src/components/<operator-short-name>.css` | Shared operator CSS (cards, tables, buttons, inspect) |
+| `console-extensions.json` | Routes and nav |
+| `package.json` | `consolePlugin.exposedModules` |
+| `locales/en/plugin__console-plugin-template.json` | English strings |
+| `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml` | RBAC for new API groups |
+
+Create any of the above if missing; when they exist, **extend** them (do not replace shared structure).
+
+---
+
+## Naming Conventions
+
+- **OPERATOR_SHORT_NAME:** recognizable short name, lowercase kebab-case (e.g. "cert-manager Operator for Red Hat OpenShift" → `cert-manager`).
+
+| Concept | Pattern | Example |
+|---------|---------|---------|
+| Page path | `/<operator-short-name>` | `/cert-manager` |
+| Page component | `src/<OperatorShortName>Page.tsx` | `src/CertManagerPage.tsx` |
+| Table components | `src/components/<KindPlural>Table.tsx` | `src/components/CertificatesTable.tsx` |
+| CSS | `src/components/<operator-short-name>.css` | `src/components/cert-manager.css` |
+| Inspect (namespaced) | `/<page>/inspect/<plural>/<namespace>/<name>` | `/cert-manager/inspect/certificates/default/my-cert` |
+| Inspect (cluster-scoped) | `/<page>/inspect/<plural>/<name>` | `/cert-manager/inspect/clusterissuers/my-issuer` |
+
+---
+
+## Operator Dashboard Column Selection
+
+Tables MUST follow this column logic (implement when building rows for ResourceTable):
+
+1. **Always:** Name (link to inspect), Namespace (if namespaced).
+2. **Optional:** Columns from CRD `additionalPrinterColumns` (priority 0; priority 1 only if total ≤ 8). Use each column’s `jsonPath`; `type: date` → `<Timestamp>`; status/conditions → Label with **`status`** prop (success/danger/warning).
+3. **Fallback** if no additionalPrinterColumns: Name, Namespace (if namespaced), Status (from `status.conditions[type=Ready]`), Age (`metadata.creationTimestamp`), Actions.
+4. **Always last:** Actions column with **Inspect** button (sky blue) and **Delete** button (red), using **ResourceTableRowActions** so `useDeleteModal` is called per row.
+5. User-provided column overrides (if any) override the above; document them in the summary.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Directories
+
+```bash
+mkdir -p src/hooks src/components/crds
+```
+
+### Step 2 — `src/hooks/useOperatorDetection.ts`
+
+Use `useK8sModel` with `{ group, version, kind }` for the primary resource. Export `OperatorStatus`, `OperatorInfo`, `<OPERATOR>_OPERATOR_INFO`, and `useOperatorDetection()`. If the file exists, add the new operator’s info and extend the hook.
+
+### Step 3 — `src/components/crds/index.ts`
+
+For each resource kind, export a **K8sModel** and a TypeScript interface extending `K8sResourceCommon` with optional `spec`/`status`. Append if the file exists.
+
+### Step 4 — `src/components/crds/Events.ts`
+
+Add `plural: 'Kind'` to **RESOURCE_TYPE_TO_KIND** for each new resource.
+
+### Step 5 — `src/components/OperatorNotInstalled.tsx`
+
+Create only if missing. Generic empty state with `EmptyState` (titleText, icon={SearchIcon}, headingLevel), `EmptyStateBody`, and operator display name message.
+
+### Step 6 — Table components (`src/components/<KindPlural>Table.tsx`)
+
+**Use ResourceTable.** One file per resource kind.
+
+- Build **columns**: array of `{ title, width? }` (Name, Namespace if namespaced, then algorithm columns, then Actions).
+- Build **rows**: from `useK8sWatchResource` list; each row’s **cells** array includes Name (Link to inspect), Namespace if namespaced, Status (Label with **status** prop), Created (Timestamp), and **`<ResourceTableRowActions resource={obj} inspectHref={inspectHref} />`** for the Actions cell.
+- Pass **loading** (`!loaded && !loadError`), **error** (`loadError?.message`), **emptyStateTitle**, **emptyStateBody**, **selectedProject** (namespaced only), **data-test**.
+- **Namespaced:** `selectedProject`, inspect href `/<page>/inspect/<plural>/${namespace}/${name}`.
+- **Cluster-scoped:** no `selectedProject`, inspect href `/<page>/inspect/<plural>/${name}`.
+
+Do **not** use VirtualizedTable or call `useDeleteModal` inside `.map()`.
+
+### Step 7 — CSS (`src/components/<operator-short-name>.css`)
+
+Add only missing classes. Use **PatternFly variables only** (no hex). Include:
+
+- `.console-plugin-template__resource-card` (margin or used in dashboard wrapper).
+- Dashboard cards wrapper: `.console-plugin-template__dashboard-cards` with `display: flex`, `flex-direction: column`, **`gap: var(--pf-v6-global--spacer--xl)`** so tables are not stuck together. Cards inside can have `margin-bottom: 0`.
+- Table styles for ResourceTable (header/data row background, borders, **text-align: left** for table data).
+- Loader (e.g. `.console-plugin-template__loader`, `.console-plugin-template__loader-dot`). **Keyframes** names must be **kebab-case** (e.g. `console-plugin-template-loader-bounce`).
+- Action buttons: `.console-plugin-template__action-inspect` (sky blue background/border), `.console-plugin-template__action-delete` (red), using `var(--pf-v6-global--palette--blue-400)`, `var(--pf-v6-global--palette--red-500)` (and hover variants).
+
+### Step 7b — Optional: Overview dashboard
+
+Optional summary count cards above tables. Component that uses `useK8sWatchResource` per kind and shows counts; Grid + Card; PF variables and `console-plugin-template__` prefix.
+
+### Step 8 — Operator page (`src/<OperatorShortName>Page.tsx`)
+
+- Use **`#ALL_NS#`** (not `'all'`) to derive `selectedProject`.
+- Loading: Spinner or shared loader.
+- Not installed: Helmet, title, OperatorNotInstalled.
+- Main view: Helmet, title, then a **wrapper div** with class `console-plugin-template__dashboard-cards` (flex, column, gap), containing one **Card** per resource kind; each Card has CardTitle and CardBody with the corresponding **Table** component. Pass **selectedProject** only to namespaced tables.
+
+### Step 9 — `src/ResourceInspect.tsx` (extend only)
+
+**Do not rewrite.** The file already implements the resource detail dashboard (Card + Grid, back button, Metadata/Labels/Annotations/Spec/Status/Events, optional sensitive-data toggle). When adding a new operator:
+
+1. **DISPLAY_NAMES:** add `plural: 'Display Name'` for each new resource.
+2. **getResourceModel(resourceType):** add cases returning the new kind’s K8sModel.
+3. **getPagePath(resourceType):** add case returning the operator page path (e.g. `'/cert-manager'`) or extend if multi-operator.
+
+Cluster-scoped: component already handles 2-segment path (plural/name). Keep URL parsing and layout as-is.
+
+### Step 10 — `console-extensions.json`
+
+- **Routes:** Append page route (`exact: true`, path `/<operator-short-name>`, component `<OperatorShortName>Page`) and inspect route (`exact: false`, path `["/<operator-short-name>/inspect"]`, component `ResourceInspect.ResourceInspect`).
+- **Plugins section:** If missing, add `console.navigation/section` with `id: "plugins"`, `insertAfter: "observe"`. Add nav link only if not present: `console.navigation/href` with `id: "<operator-short-name>"`, `href: "/<operator-short-name>"`, **`section: "plugins"`**.
+
+### Step 11 — `package.json`
+
+Add to `consolePlugin.exposedModules`: `"<OperatorShortName>Page": "./<OperatorShortName>Page"`. Add `"ResourceInspect": "./ResourceInspect"` only if not already present.
+
+### Step 12 — Locales
+
+Add all new strings to `locales/en/plugin__console-plugin-template.json` (page title, resource display names, empty states, Actions, Inspect, Delete, error messages, etc.). Do not remove existing keys. Include "Plugins" if you added the section.
+
+### Step 13 — RBAC
+
+In `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`, add or append ClusterRoles (and bindings): Reader (get, list, watch) and Admin (get, list, watch, delete) for the new API groups/resources. Use template name `{{ template "openshift-console-plugin.name" . }}-<operator-short-name>-reader` and `-admin`.
+
+---
+
+## Validation
+
+- Run **`yarn build-dev`**. It must succeed (ignore pre-existing `node_modules` errors).
+- Run **`yarn lint`** (eslint + stylelint). Fix any issues in `src/` or CSS.
+
+---
+
+## Definition of Done
+
+- [ ] Operator detected via **useK8sModel** (not consoleFetchJSON).
+- [ ] Plugins section exists; operator link under **Plugins** with **section: "plugins"**.
+- [ ] Dashboard at `/<operator-short-name>` with **ResourceTable** in Cards, wrapped in **dashboard-cards** (gap), **left-aligned** table data.
+- [ ] Inspect and Delete are **buttons** (sky blue and red); **ResourceTableRowActions** used so delete modal works per row.
+- [ ] Inspect opens ResourceInspect at `/<operator-short-name>/inspect/...` with Metadata, Labels, Annotations, Spec, Status, Events (Card + Grid, back button).
+- [ ] ResourceInspect extended with new DISPLAY_NAMES, getResourceModel, getPagePath (no layout rewrite).
+- [ ] No hex colors; no `.pf-`/`.co-` custom structure; keyframes kebab-case.
+- [ ] Locales and RBAC updated; `yarn build-dev` and `yarn lint` pass.
+
+---
+
+## Final Response Format
+
+1. **Files changed** (created/updated).
+2. **CRDs/resources** used (and any inferred values).
+3. **Validation** (build + lint).
+4. **Assumptions / risks.**

--- a/src/ResourceInspect.tsx
+++ b/src/ResourceInspect.tsx
@@ -1,0 +1,856 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import Helmet from 'react-helmet';
+import {
+  Title,
+  Card,
+  CardTitle,
+  CardBody,
+  Grid,
+  GridItem,
+  Button,
+  Label,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  Alert,
+  AlertVariant,
+  Switch,
+} from '@patternfly/react-core';
+import { ArrowLeftIcon, KeyIcon, CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { CertificateModel } from './components/crds/Certificate';
+import { IssuerModel, ClusterIssuerModel } from './components/crds/Issuer';
+import { ExternalSecretModel, ClusterExternalSecretModel } from './components/crds/ExternalSecret';
+import { SecretStoreModel, ClusterSecretStoreModel } from './components/crds/SecretStore';
+import { PushSecretModel, ClusterPushSecretModel } from './components/crds/PushSecret';
+import {
+  SecretProviderClassModel,
+  SecretProviderClassPodStatusModel,
+  SecretProviderClassPodStatus,
+} from './components/crds/SecretProviderClass';
+import { EventModel, getInvolvedObjectKind, K8sEvent } from './components/crds/Events';
+import { dump as yamlDump } from 'js-yaml';
+
+// YAML syntax colors (on black background): blue (keys), mustard yellow (values)
+const YAML_KEY_COLOR = '#60a5fa';
+const YAML_VALUE_COLOR = '#eab308';
+const HIDDEN_VALUE_PLACEHOLDER = '********';
+
+function colorizeYaml(yamlString: string): React.ReactNode {
+  const lines = yamlString.split('\n');
+  return (
+    <>
+      {lines.map((line, i) => {
+        // Key: value
+        const keyValueMatch = line.match(/^(\s*)(.+?)(\s*:\s*)(.*)$/);
+        if (keyValueMatch) {
+          const [, indent, key, sep, value] = keyValueMatch;
+          return (
+            <span key={i}>
+              {indent}
+              <span style={{ color: YAML_KEY_COLOR }}>{key}</span>
+              {sep}
+              <span style={{ color: YAML_VALUE_COLOR }}>{value}</span>
+              {'\n'}
+            </span>
+          );
+        }
+        // List item: - value
+        const listMatch = line.match(/^(\s*)(-\s+)(.*)$/);
+        if (listMatch) {
+          const [, indent, dash, rest] = listMatch;
+          return (
+            <span key={i}>
+              {indent}
+              <span style={{ color: YAML_KEY_COLOR }}>{dash.trim() || '-'}</span>
+              <span style={{ color: YAML_VALUE_COLOR }}>{rest}</span>
+              {'\n'}
+            </span>
+          );
+        }
+        // Comment or continuation line: use value color for non-empty, keep structure
+        if (line.trim().startsWith('#')) {
+          return (
+            <span key={i} style={{ color: '#6b7280' }}>
+              {line}
+              {'\n'}
+            </span>
+          );
+        }
+        return (
+          <span key={i}>
+            {line ? <span style={{ color: YAML_VALUE_COLOR }}>{line}</span> : null}
+            {'\n'}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+export const ResourceInspect: React.FC = () => {
+  const { t } = useTranslation('plugin__ocp-secrets-management');
+
+  // State for revealing sensitive data (separate for spec and status)
+  const [showSpecSensitiveData, setShowSpecSensitiveData] = React.useState(false);
+  const [showStatusSensitiveData, setShowStatusSensitiveData] = React.useState(false);
+
+  // Parse URL manually since useParams() isn't working in plugin environment
+  const pathname = window.location.pathname;
+  const pathParts = pathname.split('/');
+
+  // Expected format: /secrets-management/inspect/{resourceType}/{namespace}/{name}
+  // or: /secrets-management/inspect/{resourceType}/{name} (for cluster-scoped)
+  const baseIndex = pathParts.findIndex((part) => part === 'inspect');
+  const resourceType =
+    baseIndex >= 0 && pathParts.length > baseIndex + 1 ? pathParts[baseIndex + 1] : '';
+
+  let namespace: string | undefined;
+  let name: string;
+
+  if (pathParts.length > baseIndex + 3) {
+    // Format: /secrets-management/inspect/{resourceType}/{namespace}/{name}
+    namespace = pathParts[baseIndex + 2];
+    name = pathParts[baseIndex + 3];
+  } else {
+    // Format: /secrets-management/inspect/{resourceType}/{name} (cluster-scoped)
+    name = pathParts[baseIndex + 2] || '';
+  }
+
+  const handleBackClick = () => {
+    window.history.back();
+  };
+
+  // Determine the correct model based on resource type
+  const getResourceModel = () => {
+    switch (resourceType) {
+      case 'certificates':
+        return CertificateModel;
+      case 'issuers':
+        return IssuerModel;
+      case 'clusterissuers':
+        return ClusterIssuerModel;
+      case 'externalsecrets':
+        return ExternalSecretModel;
+      case 'clusterexternalsecrets':
+        return ClusterExternalSecretModel;
+      case 'secretstores':
+        return SecretStoreModel;
+      case 'clustersecretstores':
+        return ClusterSecretStoreModel;
+      case 'pushsecrets':
+        return PushSecretModel;
+      case 'clusterpushsecrets':
+        return ClusterPushSecretModel;
+      case 'secretproviderclasses':
+        return SecretProviderClassModel;
+      default:
+        return null;
+    }
+  };
+
+  const model = getResourceModel();
+  const isClusterScoped =
+    resourceType === 'clusterissuers' ||
+    resourceType === 'clustersecretstores' ||
+    resourceType === 'clusterexternalsecrets' ||
+    resourceType === 'clusterpushsecrets';
+
+  const [resource, loaded, loadError] = useK8sWatchResource<any>({
+    groupVersionKind: model,
+    name: name,
+    namespace: isClusterScoped ? undefined : namespace || 'demo',
+    isList: false,
+  });
+
+  // Watch SecretProviderClassPodStatus resources when inspecting a SecretProviderClass
+  const [podStatuses, podStatusesLoaded, podStatusesError] = useK8sWatchResource<
+    SecretProviderClassPodStatus[]
+  >({
+    groupVersionKind: SecretProviderClassPodStatusModel,
+    namespace: resourceType === 'secretproviderclasses' ? namespace || 'demo' : undefined,
+    isList: true,
+  });
+
+  // Watch Events for this resource (involvedObject name/kind/namespace)
+  const eventsNamespace = isClusterScoped ? 'default' : namespace || 'default';
+  const involvedKind = getInvolvedObjectKind(resourceType);
+  const eventsFieldSelector = [
+    `involvedObject.name=${name}`,
+    `involvedObject.kind=${involvedKind}`,
+    ...(!isClusterScoped && namespace ? [`involvedObject.namespace=${namespace}`] : []),
+  ].join(',');
+  const [events, eventsLoaded, eventsError] = useK8sWatchResource<K8sEvent[]>({
+    groupVersionKind: EventModel,
+    namespace: eventsNamespace,
+    isList: true,
+    fieldSelector: eventsFieldSelector,
+  });
+
+  const formatTimestamp = (timestamp: string) => {
+    if (!timestamp) return '-';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  };
+
+  const renderMetadata = () => {
+    if (!resource?.metadata) return null;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Metadata')}</CardTitle>
+        <CardBody>
+          <DescriptionList
+            isHorizontal
+            style={{
+              rowGap: '0.25rem',
+              background: '#1e1e1e',
+              paddingTop: '16px',
+              paddingLeft: '16px',
+              paddingBottom: '16px',
+            }}
+          >
+            <DescriptionListGroup
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'baseline',
+                marginBottom: 0,
+              }}
+            >
+              <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                {t('Name:')}
+              </DescriptionListTerm>
+              <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                {resource.metadata.name || '-'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {resource.kind && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Kind:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.kind}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.metadata.namespace && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Namespace:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.namespace}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.apiVersion && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('API version:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.apiVersion}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            <DescriptionListGroup
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'baseline',
+                marginBottom: 0,
+              }}
+            >
+              <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                {t('Creation timestamp:')}
+              </DescriptionListTerm>
+              <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                {formatTimestamp(resource.metadata.creationTimestamp)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {resource.metadata.uid && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('UID:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.uid}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.metadata.resourceVersion && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Resource version:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.resourceVersion}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+          </DescriptionList>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderLabels = () => {
+    const labels = resource?.metadata?.labels;
+    if (!labels || Object.keys(labels).length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Labels')}</CardTitle>
+          <CardBody>
+            <em>{t('No labels')}</em>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    const cardStyle = {
+      background: '#1e1e1e',
+      borderRadius: '4px',
+      border: '1px solid #374151',
+    };
+    return (
+      <Card style={cardStyle}>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Labels')}</CardTitle>
+        <CardBody>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {Object.entries(labels).map(([key, value]) => (
+              <Label key={key} color="blue">
+                {key}: {value}
+              </Label>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderAnnotations = () => {
+    const annotations = resource?.metadata?.annotations;
+    if (!annotations || Object.keys(annotations).length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+            {t('Annotations')}
+          </CardTitle>
+          <CardBody>
+            <em>{t('No annotations')}</em>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    const cardStyle = {
+      background: '#1e1e1e',
+      borderRadius: '4px',
+      border: '1px solid #374151',
+    };
+    return (
+      <Card style={cardStyle}>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Annotations')}</CardTitle>
+        <CardBody>
+          <DescriptionList isHorizontal style={{ rowGap: '0.25rem', background: '#1e1e1e' }}>
+            {Object.entries(annotations).map(([key, value]) => (
+              <DescriptionListGroup
+                key={key}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {key}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {value}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            ))}
+          </DescriptionList>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  // Function to check if object contains sensitive data
+  const containsSensitiveData = (obj: any): boolean => {
+    const sensitiveKeys = [
+      'password',
+      'secret',
+      'token',
+      'key',
+      'privateKey',
+      'secretKey',
+      'accessKey',
+      'secretAccessKey',
+      'clientSecret',
+      'apiKey',
+      'auth',
+      'authentication',
+      'credential',
+      'cert',
+      'certificate',
+      'tls',
+      // SecretProviderClass specific sensitive patterns
+      'tenantId',
+      'clientId',
+      'subscriptionId',
+      'resourceGroup',
+      'vaultName',
+      'keyVaultName',
+      'servicePrincipal',
+      'roleArn',
+      'region',
+      'vaultUrl',
+      'vaultAddress',
+      'vaultNamespace',
+      'vaultRole',
+      'vaultPath',
+      'parameters',
+    ];
+
+    const checkObject = (data: any): boolean => {
+      if (Array.isArray(data)) {
+        return data.some(checkObject);
+      }
+
+      if (data && typeof data === 'object') {
+        for (const [key, value] of Object.entries(data)) {
+          const lowerKey = key.toLowerCase();
+          const isSensitive = sensitiveKeys.some((sensitiveKey) =>
+            lowerKey.includes(sensitiveKey.toLowerCase()),
+          );
+
+          if (isSensitive || checkObject(value)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    };
+
+    return checkObject(obj);
+  };
+
+  const renderSpecification = () => {
+    if (!resource?.spec) return null;
+
+    const hasSensitiveData = containsSensitiveData(resource.spec);
+    const shouldHideContent = hasSensitiveData && !showSpecSensitiveData;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            {t('Specification')}
+            {hasSensitiveData && (
+              <Switch
+                id="spec-sensitive-toggle"
+                label={showSpecSensitiveData ? t('Hide sensitive data') : t('Show sensitive data')}
+                isChecked={showSpecSensitiveData}
+                onChange={(event, checked) => setShowSpecSensitiveData(checked)}
+                ouiaId="SpecificationSensitiveToggle"
+              />
+            )}
+          </div>
+        </CardTitle>
+        <CardBody>
+          <pre
+            style={{
+              padding: '16px',
+              borderRadius: '4px',
+              overflow: 'auto',
+              fontSize: '13px',
+              maxHeight: '400px',
+              background: '#1e1e1e',
+              border: '1px solid #374151',
+            }}
+          >
+            {shouldHideContent ? (
+              <span style={{ color: YAML_VALUE_COLOR }}>{HIDDEN_VALUE_PLACEHOLDER}</span>
+            ) : (
+              colorizeYaml(yamlDump(resource.spec, { lineWidth: -1 }))
+            )}
+          </pre>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderStatus = () => {
+    if (!resource?.status) return null;
+
+    // For Certificates, always show the toggle when status exists (status may reference secrets/certs);
+    // for other resources, only show when status contains sensitive-looking keys.
+    const hasSensitiveData =
+      resourceType === 'certificates' || containsSensitiveData(resource.status);
+    const shouldHideContent = hasSensitiveData && !showStatusSensitiveData;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            {t('Status')}
+            {hasSensitiveData && (
+              <Switch
+                id="status-sensitive-toggle"
+                label={
+                  showStatusSensitiveData ? t('Hide sensitive data') : t('Show sensitive data')
+                }
+                isChecked={showStatusSensitiveData}
+                onChange={(event, checked) => setShowStatusSensitiveData(checked)}
+                ouiaId="StatusSensitiveToggle"
+              />
+            )}
+          </div>
+        </CardTitle>
+        <CardBody>
+          <pre
+            style={{
+              padding: '16px',
+              borderRadius: '4px',
+              overflow: 'auto',
+              fontSize: '13px',
+              maxHeight: '400px',
+              background: '#1e1e1e',
+              border: '1px solid #374151',
+            }}
+          >
+            {shouldHideContent ? (
+              <span style={{ color: YAML_VALUE_COLOR }}>{HIDDEN_VALUE_PLACEHOLDER}</span>
+            ) : (
+              colorizeYaml(yamlDump(resource.status, { lineWidth: -1 }))
+            )}
+          </pre>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderSecretProviderClassPodStatuses = () => {
+    if (resourceType !== 'secretproviderclasses' || !resource) return null;
+
+    // Filter pod statuses that reference this SecretProviderClass
+    const relevantPodStatuses = (podStatuses || []).filter(
+      (podStatus) => podStatus.status.secretProviderClassName === resource.metadata.name,
+    );
+
+    if (relevantPodStatuses.length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+            {t('Pod Statuses')}
+          </CardTitle>
+          <CardBody>
+            <p>{t('No pods are currently using this SecretProviderClass.')}</p>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          {t('Pod Statuses')} ({relevantPodStatuses.length})
+        </CardTitle>
+        <CardBody>
+          <div style={{ overflowX: 'auto' }}>
+            <table className="pf-c-table pf-m-compact pf-m-grid-md" style={{ width: '100%' }}>
+              <thead>
+                <tr>
+                  <th>{t('Pod Name')}</th>
+                  <th>{t('Mounted')}</th>
+                  <th>{t('Created')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {relevantPodStatuses.map((podStatus) => (
+                  <tr key={podStatus.metadata.name}>
+                    <td>{podStatus.status.podName || podStatus.metadata.name}</td>
+                    <td>
+                      <Label
+                        color={podStatus.status.mounted ? 'green' : 'red'}
+                        icon={podStatus.status.mounted ? <CheckCircleIcon /> : <TimesCircleIcon />}
+                      >
+                        {podStatus.status.mounted ? t('Yes') : t('No')}
+                      </Label>
+                    </td>
+                    <td>{formatTimestamp(podStatus.metadata.creationTimestamp)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderEvents = () => {
+    if (!resource) return null;
+    const list = events ?? [];
+    const sorted = [...list].sort((a, b) => {
+      const tA = a.lastTimestamp || a.firstTimestamp || a.metadata?.creationTimestamp || '';
+      const tB = b.lastTimestamp || b.firstTimestamp || b.metadata?.creationTimestamp || '';
+      return tB.localeCompare(tA);
+    });
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          {t('Events')} {eventsLoaded && `(${sorted.length})`}
+        </CardTitle>
+        <CardBody>
+          {!eventsLoaded && <em>{t('Loading events...')}</em>}
+          {eventsLoaded && eventsError && (
+            <Alert variant={AlertVariant.warning} isInline title={t('Could not load events')}>
+              {eventsError?.message || String(eventsError)}
+            </Alert>
+          )}
+          {eventsLoaded && !eventsError && sorted.length === 0 && <em>{t('No events')}</em>}
+          {eventsLoaded && !eventsError && sorted.length > 0 && (
+            <div
+              style={{
+                overflowX: 'auto',
+                background: '#1e1e1e',
+                borderRadius: '4px',
+                border: '1px solid #374151',
+                paddingLeft: '16px',
+                paddingTop: '16px',
+              }}
+            >
+              <table className="pf-c-table pf-m-grid-md" style={{ width: '100%' }}>
+                <thead>
+                  <tr>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Type')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Reason')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Message')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Count')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Last seen')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map((evt) => (
+                    <tr key={evt.metadata?.name ?? evt.reason ?? ''}>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        <Label color={evt.type === 'Warning' ? 'orange' : 'blue'}>
+                          {evt.type || 'Normal'}
+                        </Label>
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {evt.reason ?? '-'}
+                      </td>
+                      <td
+                        style={{
+                          maxWidth: '20rem',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          paddingTop: '0.75rem',
+                          paddingBottom: '0.75rem',
+                        }}
+                        title={evt.message}
+                      >
+                        {evt.message ?? '-'}
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {evt.count ?? 1}
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {formatTimestamp(
+                          evt.lastTimestamp ||
+                            evt.firstTimestamp ||
+                            evt.metadata?.creationTimestamp,
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const getResourceTypeDisplayName = () => {
+    switch (resourceType) {
+      case 'certificates':
+        return t('Certificate');
+      case 'issuers':
+        return t('Issuer');
+      case 'clusterissuers':
+        return t('ClusterIssuer');
+      case 'externalsecrets':
+        return t('ExternalSecret');
+      case 'clusterexternalsecrets':
+        return t('ClusterExternalSecret');
+      case 'secretstores':
+        return t('SecretStore');
+      case 'clustersecretstores':
+        return t('ClusterSecretStore');
+      case 'pushsecrets':
+        return t('PushSecret');
+      case 'clusterpushsecrets':
+        return t('ClusterPushSecret');
+      case 'secretproviderclasses':
+        return t('SecretProviderClass');
+      default:
+        return t('Resource');
+    }
+  };
+
+  if (!model) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.danger} title={t('Invalid resource type')} isInline>
+          {t('The resource type "{resourceType}" is not supported.', { resourceType })}
+        </Alert>
+      </div>
+    );
+  }
+
+  // For SecretProviderClass, also wait for pod statuses to load
+  const allLoaded = resourceType === 'secretproviderclasses' ? loaded && podStatusesLoaded : loaded;
+
+  if (!allLoaded) {
+    return (
+      <div className="co-m-loader co-an-fade-in-out">
+        <div className="co-m-loader-dot__one"></div>
+        <div className="co-m-loader-dot__two"></div>
+        <div className="co-m-loader-dot__three"></div>
+      </div>
+    );
+  }
+
+  // Handle errors from both resource and pod status loading
+  const anyError =
+    loadError || (resourceType === 'secretproviderclasses' ? podStatusesError : null);
+
+  if (anyError) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.danger} title={t('Error loading resource')} isInline>
+          {anyError.message}
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!resource) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.warning} title={t('Resource not found')} isInline>
+          {t('The {resourceType} "{name}" was not found.', {
+            resourceType: getResourceTypeDisplayName(),
+            name,
+          })}
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>{t('{resourceType} details', { resourceType: getResourceTypeDisplayName() })}</title>
+      </Helmet>
+
+      <div className="co-m-pane__body">
+        <div className="co-m-pane__heading">
+          <div className="co-m-pane__name co-resource-item">
+            <Button variant="plain" onClick={handleBackClick} style={{ marginRight: '16px' }}>
+              <ArrowLeftIcon />
+            </Button>
+            <KeyIcon className="co-m-resource-icon" style={{ marginRight: '8px' }} />
+            <Title headingLevel="h1" size="lg">
+              {getResourceTypeDisplayName()}: {name}
+            </Title>
+          </div>
+        </div>
+
+        <Grid hasGutter>
+          <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+            {renderMetadata()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingLeft: '2rem' }}>
+            {renderLabels()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingRight: '2rem' }}>
+            {renderAnnotations()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingLeft: '2rem' }}>
+            {renderSpecification()}
+          </GridItem>
+          <GridItem span={6}>{renderStatus()}</GridItem>
+          <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+            {renderEvents()}
+          </GridItem>
+          {resourceType === 'secretproviderclasses' && (
+            <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+              {renderSecretProviderClassPodStatuses()}
+            </GridItem>
+          )}
+        </Grid>
+      </div>
+    </>
+  );
+};

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  EmptyState,
+  EmptyStateBody,
+  Title,
+  Alert,
+  AlertVariant,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+interface Column {
+  title: string;
+  width?: number;
+}
+
+interface Row {
+  cells: React.ReactNode[];
+}
+
+interface ResourceTableProps {
+  columns: Column[];
+  rows: Row[];
+  loading?: boolean;
+  error?: string;
+  emptyStateTitle?: string;
+  emptyStateBody?: string;
+  /** When set, fallback empty state body is project-aware (e.g. "in project X" vs "in the demo project"). */
+  selectedProject?: string;
+  'data-test'?: string;
+}
+
+export const ResourceTable: React.FC<ResourceTableProps> = ({
+  columns,
+  rows,
+  loading = false,
+  error,
+  emptyStateTitle,
+  emptyStateBody,
+  selectedProject,
+  'data-test': dataTest,
+}) => {
+  const { t } = useTranslation('plugin__ocp-secrets-management');
+
+  const defaultEmptyStateBody =
+    selectedProject && selectedProject !== 'all'
+      ? t('No resources of this type are currently available in project {{project}}.', { project: selectedProject })
+      : t('No resources of this type are currently available in the demo project.');
+
+  if (loading) {
+    return (
+      <div className="co-m-loader co-an-fade-in-out" data-test={`${dataTest}-loading`}>
+        <div className="co-m-loader-dot__one"></div>
+        <div className="co-m-loader-dot__two"></div>
+        <div className="co-m-loader-dot__three"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="co-m-pane__body" data-test={`${dataTest}-error`}>
+        <Alert
+          variant={AlertVariant.danger}
+          title={t('Error loading resources')}
+          isInline
+        >
+          {error}
+        </Alert>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="co-m-pane__body" data-test={`${dataTest}-empty`}>
+        <EmptyState>
+          <SearchIcon className="co-m-empty-state__icon" />
+          <Title size="lg" headingLevel="h4">
+            {emptyStateTitle || t('No resources found')}
+          </Title>
+          <EmptyStateBody>
+            {emptyStateBody ?? defaultEmptyStateBody}
+          </EmptyStateBody>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  // Calculate column widths - distribute evenly if no widths specified
+  const totalSpecifiedWidth = columns.reduce((sum, col) => sum + (col.width || 0), 0);
+  const hasSpecifiedWidths = totalSpecifiedWidth > 0;
+  const defaultWidth = hasSpecifiedWidths ? undefined : 100 / columns.length;
+
+  return (
+    <div className="co-m-table-grid co-m-table-grid--bordered" data-test={dataTest}>
+      <div className="table-responsive">
+        <table className="table table-hover" style={{ tableLayout: 'fixed', width: '100%' }}>
+          <thead>
+            <tr>
+              {columns.map((column, index) => {
+                const width = hasSpecifiedWidths 
+                  ? `${(column.width || 0)}%`
+                  : `${defaultWidth}%`;
+                
+                return (
+                  <th 
+                    key={index} 
+                    role="columnheader"
+                    style={{ 
+                      width,
+                      paddingLeft: '1rem',
+                      paddingRight: '1rem',
+                      textAlign: 'left',
+                      verticalAlign: 'middle'
+                    }}
+                  >
+                    {column.title}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.cells.map((cell, cellIndex) => (
+                  <td 
+                    key={cellIndex}
+                    style={{
+                      paddingLeft: '1rem',
+                      paddingRight: '1rem',
+                      textAlign: 'left',
+                      verticalAlign: 'middle',
+                      wordWrap: 'break-word',
+                      overflow: 'hidden'
+                    }}
+                  >
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/components/crds/Certificate.ts
+++ b/src/components/crds/Certificate.ts
@@ -1,0 +1,7 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const CertificateModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Certificate',
+};

--- a/src/components/crds/Events.ts
+++ b/src/components/crds/Events.ts
@@ -1,0 +1,47 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const EventModel: K8sGroupVersionKind = {
+  group: '',
+  version: 'v1',
+  kind: 'Event',
+};
+
+export interface K8sEvent {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  type?: string;
+  reason?: string;
+  message?: string;
+  count?: number;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  involvedObject?: {
+    kind?: string;
+    name?: string;
+    namespace?: string;
+    [key: string]: unknown;
+  };
+}
+
+const RESOURCE_TYPE_TO_KIND: Record<string, string> = {
+  certificates: 'Certificate',
+  issuers: 'Issuer',
+  clusterissuers: 'ClusterIssuer',
+  externalsecrets: 'ExternalSecret',
+  clusterexternalsecrets: 'ClusterExternalSecret',
+  secretstores: 'SecretStore',
+  clustersecretstores: 'ClusterSecretStore',
+  pushsecrets: 'PushSecret',
+  clusterpushsecrets: 'ClusterPushSecret',
+  secretproviderclasses: 'SecretProviderClass',
+};
+
+export function getInvolvedObjectKind(resourceType: string): string {
+  return RESOURCE_TYPE_TO_KIND[resourceType] ?? resourceType;
+}

--- a/src/components/crds/ExternalSecret.ts
+++ b/src/components/crds/ExternalSecret.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const ExternalSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ExternalSecret',
+};
+
+export const ClusterExternalSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterExternalSecret',
+};

--- a/src/components/crds/Issuer.ts
+++ b/src/components/crds/Issuer.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const IssuerModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Issuer',
+};
+
+export const ClusterIssuerModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'ClusterIssuer',
+};

--- a/src/components/crds/PushSecret.ts
+++ b/src/components/crds/PushSecret.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const PushSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'PushSecret',
+};
+
+export const ClusterPushSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterPushSecret',
+};

--- a/src/components/crds/SecretProviderClass.ts
+++ b/src/components/crds/SecretProviderClass.ts
@@ -1,0 +1,30 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const SecretProviderClassModel: K8sGroupVersionKind = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClass',
+};
+
+export const SecretProviderClassPodStatusModel: K8sGroupVersionKind = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClassPodStatus',
+};
+
+export interface SecretProviderClassPodStatus {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  status?: {
+    secretProviderClassName?: string;
+    podName?: string;
+    mounted?: boolean;
+    [key: string]: unknown;
+  };
+}

--- a/src/components/crds/SecretStore.ts
+++ b/src/components/crds/SecretStore.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const SecretStoreModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'SecretStore',
+};
+
+export const ClusterSecretStoreModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterSecretStore',
+};


### PR DESCRIPTION
## What

- docs/promts.md — Spec and prompt for adding a new operator to the plugin: end goal (operator dashboard, inspect page, sidebar link), shared components to use, a copy-paste prompt template (operator name, detection model, resource kinds, optional namespace/columns), and explicit “What NOT to do” and critical rules (e.g. useK8sModel only, #ALL_NS#, single inspect route, PatternFly 6 EmptyState, CSS/i18n constraints).
- src/components/ResourceTable.tsx — Shared table component used for all operator resource lists: configurable columns and rows, loading/error/empty states, optional selectedProject for empty-state copy, and ResourceTableRowActions for per-row Inspect + Delete buttons (so useDeleteModal is used per row, not inside .map()).
- src/ResourceInspect.tsx — Shared resource detail page: Card + Grid layout with Metadata, Labels, Annotations, Spec, Status, and Events, back button, and optional “Show/Hide sensitive data” for spec/status. Designed to be extended per operator via DISPLAY_NAMES, getResourceModel, and getPagePath instead of rewriting the component.

## Why

- Consistency and speed: A single, documented prompt and shared components let anyone (or an AI) add a new operator in a repeatable way: same dashboard layout, same table and inspect UX, same patterns (no VirtualizedTable, no useDeleteModal in .map(), correct EmptyState/namespace/route usage).
- Fewer mistakes: The doc encodes lessons learned (RBAC/consoleFetchJSON, #ALL_NS#, PatternFly 6 APIs, reserved CSS classes, one inspect route, Plugins section) so new operators avoid known pitfalls.
- Template reuse: ResourceTable and ResourceInspect become the standard building blocks for all operator UIs in this plugin, so the template stays maintainable as more operators are added.

How to run, locally:

1. Do the `oc login` to the cluster
2. Run the promt ( docs/promt.md) in cursor with the Operator Name ( Wait for cursor to finish writing the code before going to the next step), accept the changes made by cursor.
3. in one console run 'yarn start'
4. in another console run 'yarn start-console'
5. Now you can see the result in on 'localhost:9000/'
